### PR TITLE
Add cloudwatch-log-policy module

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,3 +1,5 @@
 # Modules
 ":floppy_disk: cloudwatch-log-group":
 - modules/cloudwatch-log-group/**/*
+":floppy_disk: cloudwatch-log-policy":
+- modules/cloudwatch-log-policy/**/*

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -43,3 +43,6 @@
 - color: "fbca04"
   description: "This issue or pull request is related to cloudwatch-log-group module."
   name: ":floppy_disk: cloudwatch-log-group"
+- color: "fbca04"
+  description: "This issue or pull request is related to cloudwatch-log-policy module."
+  name: ":floppy_disk: cloudwatch-log-policy"

--- a/examples/cloudwatch-log-policy-es/main.tf
+++ b/examples/cloudwatch-log-policy-es/main.tf
@@ -1,0 +1,25 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+data "aws_caller_identity" "this" {}
+
+###################################################
+# Resource Policy for CloudWatch Logs
+###################################################
+
+module "log_policy" {
+  source = "../../modules/cloudwatch-log-policy"
+  # source  = "tedilabs/observability/aws//modules/cloudwatch-log-policy"
+  # version = "~> 0.1.0"
+
+  name    = "es"
+  service = "es.amazonaws.com"
+
+  statements = [
+    {
+      log_groups        = ["/aws/es/*"]
+      account_whitelist = [data.aws_caller_identity.this.account_id]
+    }
+  ]
+}

--- a/examples/cloudwatch-log-policy-es/outputs.tf
+++ b/examples/cloudwatch-log-policy-es/outputs.tf
@@ -1,0 +1,3 @@
+output "log_policy" {
+  value = module.log_policy
+}

--- a/examples/cloudwatch-log-policy-es/versions.tf
+++ b/examples/cloudwatch-log-policy-es/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/examples/cloudwatch-log-policy-route53/main.tf
+++ b/examples/cloudwatch-log-policy-route53/main.tf
@@ -1,0 +1,25 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+data "aws_caller_identity" "this" {}
+
+###################################################
+# Resource Policy for CloudWatch Logs
+###################################################
+
+module "log_policy" {
+  source = "../../modules/cloudwatch-log-policy"
+  # source  = "tedilabs/observability/aws//modules/cloudwatch-log-policy"
+  # version = "~> 0.1.0"
+
+  name    = "route53"
+  service = "route53.amazonaws.com"
+
+  statements = [
+    {
+      log_groups        = ["/aws/route53/*"]
+      account_whitelist = [data.aws_caller_identity.this.account_id]
+    }
+  ]
+}

--- a/examples/cloudwatch-log-policy-route53/outputs.tf
+++ b/examples/cloudwatch-log-policy-route53/outputs.tf
@@ -1,0 +1,3 @@
+output "log_policy" {
+  value = module.log_policy
+}

--- a/examples/cloudwatch-log-policy-route53/versions.tf
+++ b/examples/cloudwatch-log-policy-route53/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/modules/cloudwatch-log-policy/README.md
+++ b/modules/cloudwatch-log-policy/README.md
@@ -1,0 +1,49 @@
+# cloudwatch-log-policy
+
+This module creates following resources.
+
+- `aws_cloudwatch_log_policy`
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.22 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.25.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_log_resource_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_resource_policy) | resource |
+| [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_name"></a> [name](#input\_name) | (Required) The name of the CloudWatch Logs resource policy. | `string` | n/a | yes |
+| <a name="input_service"></a> [service](#input\_service) | (Required) Specify the identity of the AWS service principal to allow delivering logs to this account. Valid values are `es.amazonaws.com`, `route53.amazonaws.com`. | `string` | n/a | yes |
+| <a name="input_statements"></a> [statements](#input\_statements) | (Required) A list of statements for CloudWatch Logs resource policy. Each item of `statements` as defined below.<br>    (Required) `log_groups` - A list of Log group patterns that the resource policy applies to. Whildcard is supported. Configure `*` to allow all log groups.<br>    (Optional) `account_whiteilst` - A whitelist of AWS Account IDs making the call to CloudWatch Logs.<br>    (Optional) `resource_whiteilst` - A whitelist of the ARN of AWS resources making the call to CloudWatch Logs. | `list(map(set(string)))` | `[]` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_name"></a> [name](#output\_name) | The name of CloudWatch Logs resource policy. |
+| <a name="output_service"></a> [service](#output\_service) | The identity of the AWS service principal which is allowed to delivery logs to this account. |
+| <a name="output_statements"></a> [statements](#output\_statements) | The list of statements for CloudWatch Logs resource policy. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/cloudwatch-log-policy/main.tf
+++ b/modules/cloudwatch-log-policy/main.tf
@@ -1,0 +1,19 @@
+locals {
+  metadata = {
+    package = "terraform-aws-observability"
+    version = trimspace(file("${path.module}/../../VERSION"))
+    module  = basename(path.module)
+    name    = var.name
+  }
+}
+
+
+###################################################
+# Resource Policy of CloudWatch Logs
+###################################################
+
+resource "aws_cloudwatch_log_resource_policy" "this" {
+  policy_name = var.name
+
+  policy_document = data.aws_iam_policy_document.this.json
+}

--- a/modules/cloudwatch-log-policy/outputs.tf
+++ b/modules/cloudwatch-log-policy/outputs.tf
@@ -1,0 +1,22 @@
+output "name" {
+  description = "The name of CloudWatch Logs resource policy."
+  value       = aws_cloudwatch_log_resource_policy.this.policy_name
+}
+
+output "service" {
+  description = "The identity of the AWS service principal which is allowed to delivery logs to this account."
+  value       = var.service
+}
+
+output "statements" {
+  description = "The list of statements for CloudWatch Logs resource policy."
+  value = {
+    for idx, statement in var.statements :
+    "${var.name}-${idx}" => {
+      log_groups = statement.log_groups
+
+      account_whitelist  = try(statement.account_whitelist, null)
+      resource_whitelist = try(statement.resource_whitelist, null)
+    }
+  }
+}

--- a/modules/cloudwatch-log-policy/policies.tf
+++ b/modules/cloudwatch-log-policy/policies.tf
@@ -1,0 +1,65 @@
+data "aws_caller_identity" "this" {}
+data "aws_region" "this" {}
+
+locals {
+  account_id = data.aws_caller_identity.this.account_id
+  region     = data.aws_region.this.name
+
+  service_actions = {
+    "es.amazonaws.com" = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:PutLogEventsBatch",
+    ]
+    "route53.amazonaws.com" = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+  }
+}
+
+###################################################
+# Resource Policy
+###################################################
+
+data "aws_iam_policy_document" "this" {
+  dynamic "statement" {
+    for_each = var.statements
+
+    content {
+      sid = "${var.name}-${statement.key}"
+
+      actions = local.service_actions[var.service]
+
+      resources = [
+        for log_group in statement.value.log_groups :
+        "arn:aws:logs:${local.region}:${local.account_id}:log-group:${log_group}"
+      ]
+
+      principals {
+        identifiers = [var.service]
+        type        = "Service"
+      }
+
+      dynamic "condition" {
+        for_each = try([statement.value.account_whitelist], [])
+
+        content {
+          test     = "StringEquals"
+          variable = "aws:SourceAccount"
+          values   = condition.value
+        }
+      }
+
+      dynamic "condition" {
+        for_each = try([statement.value.resource_whitelist], [])
+
+        content {
+          test     = "ArnLike"
+          variable = "aws:SourceArn"
+          values   = condition.value
+        }
+      }
+    }
+  }
+}

--- a/modules/cloudwatch-log-policy/variables.tf
+++ b/modules/cloudwatch-log-policy/variables.tf
@@ -1,0 +1,27 @@
+variable "name" {
+  description = "(Required) The name of the CloudWatch Logs resource policy."
+  type        = string
+}
+
+variable "service" {
+  description = "(Required) Specify the identity of the AWS service principal to allow delivering logs to this account. Valid values are `es.amazonaws.com`, `route53.amazonaws.com`."
+  type        = string
+  nullable    = false
+
+  validation {
+    condition     = contains(["es.amazonaws.com", "route53.amazonaws.com"], var.service)
+    error_message = "Valid values for `service` are `es.amazonaws.com`, `route53.amazonaws.com`."
+  }
+}
+
+variable "statements" {
+  description = <<EOF
+  (Required) A list of statements for CloudWatch Logs resource policy. Each item of `statements` as defined below.
+    (Required) `log_groups` - A list of Log group patterns that the resource policy applies to. Whildcard is supported. Configure `*` to allow all log groups.
+    (Optional) `account_whiteilst` - A whitelist of AWS Account IDs making the call to CloudWatch Logs.
+    (Optional) `resource_whiteilst` - A whitelist of the ARN of AWS resources making the call to CloudWatch Logs.
+  EOF
+  type        = list(map(set(string)))
+  default     = []
+  nullable    = false
+}

--- a/modules/cloudwatch-log-policy/versions.tf
+++ b/modules/cloudwatch-log-policy/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.2"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.22"
+    }
+  }
+}


### PR DESCRIPTION
### Background

- Add `cloudwatch-log-policy` module to support Resource Policy for CloudWatch Logs.
- Add examples for `cloudwatch-log-policy` module.