### PR TITLE
Support delivery.logs.amazonaws.com service for cloudwatch-log-policy module

### DIFF
--- a/modules/cloudwatch-log-policy/README.md
+++ b/modules/cloudwatch-log-policy/README.md
@@ -36,7 +36,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_name"></a> [name](#input\_name) | (Required) The name of the CloudWatch Logs resource policy. | `string` | n/a | yes |
-| <a name="input_service"></a> [service](#input\_service) | (Required) Specify the identity of the AWS service principal to allow delivering logs to this account. Valid values are `es.amazonaws.com`, `route53.amazonaws.com`. | `string` | n/a | yes |
+| <a name="input_service"></a> [service](#input\_service) | (Required) Specify the identity of the AWS service principal to allow delivering logs to this account. Valid values are `delivery.logs.amazonaws.com`, `es.amazonaws.com`, `route53.amazonaws.com`. | `string` | n/a | yes |
 | <a name="input_statements"></a> [statements](#input\_statements) | (Required) A list of statements for CloudWatch Logs resource policy. Each item of `statements` as defined below.<br>    (Required) `log_groups` - A list of Log group patterns that the resource policy applies to. Whildcard is supported. Configure `*` to allow all log groups.<br>    (Optional) `account_whiteilst` - A whitelist of AWS Account IDs making the call to CloudWatch Logs.<br>    (Optional) `resource_whiteilst` - A whitelist of the ARN of AWS resources making the call to CloudWatch Logs. | `list(map(set(string)))` | `[]` | no |
 
 ## Outputs

--- a/modules/cloudwatch-log-policy/policy.tf
+++ b/modules/cloudwatch-log-policy/policy.tf
@@ -6,6 +6,10 @@ locals {
   region     = data.aws_region.this.name
 
   service_actions = {
+    "delivery.logs.amazonaws.com" = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
     "es.amazonaws.com" = [
       "logs:CreateLogStream",
       "logs:PutLogEvents",

--- a/modules/cloudwatch-log-policy/variables.tf
+++ b/modules/cloudwatch-log-policy/variables.tf
@@ -4,13 +4,13 @@ variable "name" {
 }
 
 variable "service" {
-  description = "(Required) Specify the identity of the AWS service principal to allow delivering logs to this account. Valid values are `es.amazonaws.com`, `route53.amazonaws.com`."
+  description = "(Required) Specify the identity of the AWS service principal to allow delivering logs to this account. Valid values are `delivery.logs.amazonaws.com`, `es.amazonaws.com`, `route53.amazonaws.com`."
   type        = string
   nullable    = false
 
   validation {
-    condition     = contains(["es.amazonaws.com", "route53.amazonaws.com"], var.service)
-    error_message = "Valid values for `service` are `es.amazonaws.com`, `route53.amazonaws.com`."
+    condition     = contains(["delivery.logs.amazonaws.com", "es.amazonaws.com", "route53.amazonaws.com"], var.service)
+    error_message = "Valid values for `service` are `delivery.logs.amazonaws.com`, `es.amazonaws.com`, `route53.amazonaws.com`."
   }
 }
 


### PR DESCRIPTION
### Background

- Support `delivery.logs.amazonaws.com` service for `cloudwatch-log-policy` module
  - MSK Cluster and Route53 Resolver use `delivery.logs.amazonaws.com` service principal for log delivery.