### PR TITLE
Support skip_destroy for cloudwatch-log-group module

### DIFF
--- a/examples/cloudwatch-log-group-full/main.tf
+++ b/examples/cloudwatch-log-group-full/main.tf
@@ -12,7 +12,8 @@ module "log_group" {
   # source  = "tedilabs/observability/aws//modules/cloudwatch-log-group"
   # version = "~> 0.2.0"
 
-  name = "/tedilabs/test"
+  name         = "/tedilabs/test"
+  skip_destroy = false
 
   retention_in_days  = 7
   encryption_kms_key = null

--- a/modules/cloudwatch-log-group/README.md
+++ b/modules/cloudwatch-log-group/README.md
@@ -10,14 +10,14 @@ This module creates following resources.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.22 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.55 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.52.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.64.0 |
 
 ## Modules
 
@@ -42,7 +42,8 @@ This module creates following resources.
 | <a name="input_resource_group_description"></a> [resource\_group\_description](#input\_resource\_group\_description) | (Optional) The description of Resource Group. | `string` | `"Managed by Terraform."` | no |
 | <a name="input_resource_group_enabled"></a> [resource\_group\_enabled](#input\_resource\_group\_enabled) | (Optional) Whether to create Resource Group to find and group AWS resources which are created by this module. | `bool` | `true` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | (Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. | `string` | `""` | no |
-| <a name="input_retention_in_days"></a> [retention\_in\_days](#input\_retention\_in\_days) | (Optional) Specify the number of days to retain log events in the log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0. If you select 0, the events in the log group are always retained and never expire. Default to `90` days. | `number` | `90` | no |
+| <a name="input_retention_in_days"></a> [retention\_in\_days](#input\_retention\_in\_days) | (Optional) Specify the number of days to retain log events in the log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653, and 0. If you select 0, the events in the log group are always retained and never expire. Default to `90` days. | `number` | `90` | no |
+| <a name="input_skip_destroy"></a> [skip\_destroy](#input\_skip\_destroy) | (Optional) Set to true if you do not wish the log group to be deleted at destroy time, and instead just remove the log group from the Terraform state. Defaults to `false`. | `bool` | `false` | no |
 | <a name="input_streams"></a> [streams](#input\_streams) | (Optional) A list of log streams for the CloudWatch log group. | `set(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A map of tags to add to all resources. | `map(string)` | `{}` | no |
 

--- a/modules/cloudwatch-log-group/main.tf
+++ b/modules/cloudwatch-log-group/main.tf
@@ -19,8 +19,11 @@ locals {
 # CloudWatch Log Group
 ###################################################
 
+# INFO: Not supported attributes
+# - `name_prefix` (Not used)
 resource "aws_cloudwatch_log_group" "this" {
-  name = var.name
+  name         = var.name
+  skip_destroy = var.skip_destroy
 
   retention_in_days = var.retention_in_days
   kms_key_id        = var.encryption_kms_key

--- a/modules/cloudwatch-log-group/variables.tf
+++ b/modules/cloudwatch-log-group/variables.tf
@@ -4,8 +4,15 @@ variable "name" {
   nullable    = false
 }
 
+variable "skip_destroy" {
+  description = "(Optional) Set to true if you do not wish the log group to be deleted at destroy time, and instead just remove the log group from the Terraform state. Defaults to `false`."
+  type        = bool
+  default     = false
+  nullable    = false
+}
+
 variable "retention_in_days" {
-  description = "(Optional) Specify the number of days to retain log events in the log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0. If you select 0, the events in the log group are always retained and never expire. Default to `90` days."
+  description = "(Optional) Specify the number of days to retain log events in the log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653, and 0. If you select 0, the events in the log group are always retained and never expire. Default to `90` days."
   type        = number
   default     = 90
   nullable    = false

--- a/modules/cloudwatch-log-group/versions.tf
+++ b/modules/cloudwatch-log-group/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.2"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.22"
+      version = ">= 4.55"
     }
   }
 }

--- a/modules/cloudwatch-log-policy/README.md
+++ b/modules/cloudwatch-log-policy/README.md
@@ -9,7 +9,7 @@ This module creates following resources.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.22 |
 
 ## Providers

--- a/modules/cloudwatch-log-policy/versions.tf
+++ b/modules/cloudwatch-log-policy/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.2"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {


### PR DESCRIPTION
### :wave: Background
<!-- Please explain the background or motivation for this change. -->

- Support skip_destroy for cloudwatch-log-group module
- Close #9 
- Close #4 