### PR TITLE
chore: update copyright year to 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ Like this project? Follow the repository on [GitHub](https://github.com/tedilabs
 
 Provided under the terms of the [Apache License](LICENSE).
 
-Copyright © 2022-2023, [Byungjin Park](https://www.posquit0.com).
+Copyright © 2022-2025, [Byungjin Park](https://www.posquit0.com).


### PR DESCRIPTION
## Summary
- Updated copyright year in README.md from "2022-2023" to "2022-2025"

## Test plan
- [x] Verify README.md displays updated copyright information
- [x] No functional changes, documentation only