### PR TITLE
fix(examples): correct terraform and provider version constraints

### DIFF
--- a/examples/cloudwatch-log-group-full/versions.tf
+++ b/examples/cloudwatch-log-group-full/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/cloudwatch-log-group-simple/versions.tf
+++ b/examples/cloudwatch-log-group-simple/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/cloudwatch-oam-cross-account-observability/versions.tf
+++ b/examples/cloudwatch-oam-cross-account-observability/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 6.0"
     }
   }
 }


### PR DESCRIPTION
## What & why

Three `examples/*` roots pin an `aws` provider upper bound *below* what their own local modules
require, so `terraform init` cannot resolve a provider version and the examples are unusable as
checked in.

The binding lower bound comes from outside this repo: `modules/cloudwatch-log-group`,
`modules/cloudwatch-oam-sink` and `modules/cloudwatch-oam-link` all call
`tedilabs/misc/aws//modules/resource-group` (v0.12.0), which requires `aws >= 6.0`. The roots pinned
`aws = "~> 4.0"`, which excludes it.

Real error, captured on `main` in `examples/cloudwatch-log-group-simple` before this change:

```
Downloading registry.terraform.io/tedilabs/misc/aws 0.12.0 for log_group.resource_group...
- Finding hashicorp/aws versions matching "~> 4.0, >= 4.60.0, >= 6.0.0"...

Error: Failed to query available provider packages

Could not retrieve the list of available versions for provider hashicorp/aws:
no available releases match the given constraints ~> 4.0, >= 4.60.0, >= 6.0.0
```

`required_version` was also stale at `~> 1.5`.

## Convention applied

- terraform: `required_version = "~> x.y"` → `~> 1.12`
- providers: `version = "~> x.0"` → `aws = "~> 6.0"`

`~> 6.0` is sufficient without pinning a minor floor: Terraform intersects every constraint in the
module graph, so `~> 6.0` ∩ `>= 6.0` ∩ `>= 4.60` (or `>= 5.58`) = `[6.0, 7.0)`. All three roots
resolved to `hashicorp/aws v6.58.0` below.

These roots declare no non-`aws` providers, so none were added or changed.

## Changed roots

| Example root | `required_version` before → after | `aws` before → after | Why |
|---|---|---|---|
| `examples/cloudwatch-log-group-full` | `~> 1.5` → `~> 1.12` | `~> 4.0` → `~> 6.0` | init-breaking conflict |
| `examples/cloudwatch-log-group-simple` | `~> 1.5` → `~> 1.12` | `~> 4.0` → `~> 6.0` | init-breaking conflict |
| `examples/cloudwatch-oam-cross-account-observability` | `~> 1.5` → `~> 1.12` | `~> 4.0` → `~> 6.0` | init-breaking conflict |

3 init-breaking conflicts, 0 style-only violations.

### Not changed

`examples/cloudwatch-log-policy-es` and `examples/cloudwatch-log-policy-route53` also sit at
`~> 1.5` / `aws ~> 4.0`, but they are deliberately left alone: their only module,
`modules/cloudwatch-log-policy`, requires just `aws >= 4.22` and pulls in no resource group, so their
constraint set is non-empty and `init` resolves. They are neither an init-breaking conflict nor a
style violation of the `~> x.y` / `~> x.0` convention, so they are out of scope for this PR.

## Verification

`terraform fmt -recursive -check .` → passes.

Then per root, serially, with a private `TF_PLUGIN_CACHE_DIR`:
`terraform init -backend=false && terraform validate`.

| Root | Result |
|---|---|
| `examples/cloudwatch-log-group-full` | **init OK, validate OK** — `Finding hashicorp/aws versions matching ">= 4.60.0, >= 6.0.0, ~> 6.0"` → `Installing hashicorp/aws v6.58.0` → `Terraform has been successfully initialized!` → `Success! The configuration is valid.` |
| `examples/cloudwatch-log-group-simple` | **init OK, validate OK** — `">= 4.60.0, >= 6.0.0, ~> 6.0"` → `v6.58.0` → `Success! The configuration is valid.` |
| `examples/cloudwatch-oam-cross-account-observability` | **init OK, validate OK** — `">= 5.58.0, >= 6.0.0, ~> 6.0"` → `v6.58.0` → `Success! The configuration is valid.` |

No warnings. All `.terraform/` directories and `.terraform.lock.hcl` files were removed afterwards;
`git status --porcelain` shows only the three `versions.tf` files.

## Pre-existing failures newly exposed

None. All three roots reach `validate` and pass cleanly, so CI for them should go green with this PR
alone.

## Related PRs

None to cross-reference — this repo has had no other constraint-alignment work in this sweep, so
there is no sibling `chore/deps-align-child-module-versions` or `docs/align-readme-example-versions`
PR here. The only other open PRs are dependabot #38 and #39, which touch `.github/workflows/**`
only; verified disjoint from this PR's file set (`examples/*/versions.tf` only).
